### PR TITLE
Add a basicauth-checking middleware

### DIFF
--- a/basicauth/basicauthutils.py
+++ b/basicauth/basicauthutils.py
@@ -1,6 +1,9 @@
 import base64
 import binascii
+
 from urllib.parse import unquote_plus
+
+from django.conf import settings
 
 
 def extract_basicauth(authorization_header, encoding='utf-8'):
@@ -29,3 +32,26 @@ def extract_basicauth(authorization_header, encoding='utf-8'):
 
     username, password = map(unquote_plus, splitted)
     return username, password
+
+
+def validate_request(request):
+    """Check an incoming request.
+
+    Returns:
+        - None if authentication failed
+        - the validated username otherwise
+    """
+    if 'HTTP_AUTHORIZATION' not in request.META:
+        return None
+
+    authorization_header = request.META['HTTP_AUTHORIZATION']
+    ret = extract_basicauth(authorization_header)
+    if not ret:
+        return None
+
+    username, password = ret
+
+    if settings.BASICAUTH_USERS.get(username) != password:
+        return None
+
+    return username

--- a/basicauth/decorators.py
+++ b/basicauth/decorators.py
@@ -11,5 +11,6 @@ def basic_auth_required(func):
         if validated_username is None:
             return HttpResponseUnauthorized()
         else:
+            request.META['REMOTE_USER'] = validated_username
             return func(request, *args, **kwargs)
     return _wrapped

--- a/basicauth/middleware.py
+++ b/basicauth/middleware.py
@@ -1,0 +1,11 @@
+from .basicauthutils import validate_request
+from .response import HttpResponseUnauthorized
+
+
+class BasicAuthMiddleware:
+    def process_request(self, request):
+        validated_username = validate_request(request)
+        if validated_username is None:
+            return HttpResponseUnauthorized()
+        else:
+            return None

--- a/basicauth/middleware.py
+++ b/basicauth/middleware.py
@@ -8,4 +8,5 @@ class BasicAuthMiddleware:
         if validated_username is None:
             return HttpResponseUnauthorized()
         else:
+            request.META['REMOTE_USER'] = validated_username
             return None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,7 @@ settings.configure(
     DATABASES={"default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": ":memory:"
-    }}
+    }},
+    ROOT_URLCONF='tests.testing_urls',
 )
 django.setup()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -9,7 +9,7 @@ class TestBasicAuthDecorator(TestCase):
 
     def test__it(self):
         res = self.client.get("/decorated/", HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
-        self.assertEqual(res.content, b"Called")
+        self.assertEqual(res.content, b"Called; login=username")
 
     def test__hasnt_authorization_header(self):
         res = self.client.get("/decorated/")

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from django.test import RequestFactory
 from django.test.utils import override_settings
 
 
@@ -7,27 +6,15 @@ from django.test.utils import override_settings
     BASICAUTH_USERS={"username": "password"}
 )
 class TestBasicAuthDecorator(TestCase):
-    rf = RequestFactory()
-
-    def _callFUT(self, *args, **kwargs):
-        from basicauth.decorators import basic_auth_required
-
-        def dummy_view(*args, **kwargs):
-            return "Called"
-
-        return basic_auth_required(dummy_view)(*args, **kwargs)
 
     def test__it(self):
-        req = self.rf.get("/", HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
-        res = self._callFUT(req)
-        self.assertEqual(res, "Called")
+        res = self.client.get("/decorated/", HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
+        self.assertEqual(res.content, b"Called")
 
     def test__hasnt_authorization_header(self):
-        req = self.rf.get("/")
-        res = self._callFUT(req)
+        res = self.client.get("/decorated/")
         self.assertEqual(res.status_code, 401)
 
     def test__invalid_user(self):
-        req = self.rf.get("/", HTTP_AUTHORIZATION="Basic aW52YWxpZDppbnZhbGlk")
-        res = self._callFUT(req)
+        res = self.client.get("/decorated/", HTTP_AUTHORIZATION="Basic aW52YWxpZDppbnZhbGlk")
         self.assertEqual(res.status_code, 401)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -12,7 +12,7 @@ from django.test.utils import override_settings
 class TestBasicAuthMiddleware(TestCase):
     def test__it(self):
         res = self.client.get("/decorated/", HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
-        self.assertEqual(res.content, b"Called")
+        self.assertEqual(res.content, b"Called; login=username")
 
     def test__hasnt_authorization_header(self):
         res = self.client.get("/decorated/")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import TestCase
+from django.test import RequestFactory
+from django.test.utils import override_settings
+
+
+@override_settings(
+    BASICAUTH_USERS={"username": "password"},
+    MIDDLEWARE_CLASSES=['basicauth.middleware.BasicAuthMiddleware'] + list(settings.MIDDLEWARE_CLASSES),
+)
+class TestBasicAuthMiddleware(TestCase):
+    def test__it(self):
+        res = self.client.get("/decorated/", HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
+        self.assertEqual(res.content, b"Called")
+
+    def test__hasnt_authorization_header(self):
+        res = self.client.get("/decorated/")
+        self.assertEqual(res.status_code, 401)
+
+    def test__invalid_user(self):
+        res = self.client.get("/decorated/", HTTP_AUTHORIZATION="Basic aW52YWxpZDppbnZhbGlk")
+        self.assertEqual(res.status_code, 401)

--- a/tests/testing_urls.py
+++ b/tests/testing_urls.py
@@ -1,0 +1,17 @@
+from django.conf.urls import url
+from django.http import HttpResponse
+
+from basicauth.decorators import basic_auth_required
+
+
+def naked_view(request, *args, **kwargs):
+    return HttpResponse("Called")
+
+
+decorated_view = basic_auth_required(naked_view)
+
+
+urlpatterns = [
+    url(r'^decorated/', decorated_view),
+    url(r'^naked/', naked_view),
+]

--- a/tests/testing_urls.py
+++ b/tests/testing_urls.py
@@ -5,7 +5,8 @@ from basicauth.decorators import basic_auth_required
 
 
 def naked_view(request, *args, **kwargs):
-    return HttpResponse("Called")
+    username = request.META.get('REMOTE_USER')
+    return HttpResponse("Called; login=%s" % username)
 
 
 decorated_view = basic_auth_required(naked_view)


### PR DESCRIPTION
This would add a BasicAuthMiddleware doing a similar job to the current decorator, as suggested in #2 .

In the process of writing this PR, I have felt it useful to alter the code layout to share code between decorators and middleware.
I advise reviewing the PR one commit as a time: each is an atomic unit, and tox tests pass on each commit.