### PR TITLE
Support py38, py39 and drop unsupported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,15 +11,16 @@ Tested under...
 
 * Python
 
-  * 2.7
   * 3.6
   * 3.7
+  * 3.8
+  * 3.9
 
 * Django
 
-  * 1.11
-  * 2.1
   * 2.2
+  * 3.0
+  * 3.1
 
 Installation
 ============
@@ -49,7 +50,6 @@ or by a middleware.
         ...
     )
 
-The name of ``MIDDLEWARE`` settings is ``MIDDLEWARE_CLASSES`` on Django 1.8.
 
 Basic Auth for specific requests only
 -------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description="Basic auth utilities for Django.",
     long_description=README + '\n\n' + CHANGES,
     packages=['basicauth'],
-    install_requires=['Django>=1.11'],
+    install_requires=['Django>=2.0'],
     include_package_data=True,
     test_suite="tests",
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist =
     py27-django{111}
     py36-django{111,21,22}
     py37-django{111,21,22}
+    py38-django{21,22,30,31}
+    py39-django{21,22,30,31}
     flake8
 
 [testenv]
@@ -10,10 +12,14 @@ basepython =
     py27: python2.7
     py36: python3.6
     py37: python3.7
+    py38: python3.8
+    py39: python3.9
 deps =
     django111: Django>=1.11,<2.0
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 commands =
     python -m unittest discover
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,18 @@
 [tox]
 envlist =
-    py27-django{111}
-    py36-django{111,21,22}
-    py37-django{111,21,22}
-    py38-django{21,22,30,31}
-    py39-django{21,22,30,31}
+    py36-django{22}
+    py37-django{22}
+    py38-django{22,30,31}
+    py39-django{22,30,31}
     flake8
 
 [testenv]
 basepython =
-    py27: python2.7
     py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9
 deps =
-    django111: Django>=1.11,<2.0
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
I use this library today and it worked well.
So, I added py3.8,py3.9 and django3.0,django3.1.
Also, py2.7, django 1.11 and django 2.0 have been removed as they are no longer supported.

```shell
$ tox
...
I use this library today and it worked well.
So, I added py3.8,py3.9 and django3.0,django3.1.
Also dropped py2.7 and django 1.11.

```shell
$ tox
...
_________________________________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________________________________
ERROR:  py36-django21: InterpreterNotFound: python3.6
ERROR:  py36-django22: InterpreterNotFound: python3.6
  py37-django21: commands succeeded
  py37-django22: commands succeeded
  py38-django21: commands succeeded
  py38-django22: commands succeeded
  py38-django30: commands succeeded
  py38-django31: commands succeeded
  py39-django21: commands succeeded
  py39-django22: commands succeeded
  py39-django30: commands succeeded
  py39-django31: commands succeeded
ERROR:  flake8: InterpreterNotFound: python3.6
```