### PR TITLE
Added the basic_auth_disabled decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,24 @@ Authenticated users can pass it without `Basic ...` header.
 ``target_test`` accepts ``typing.Callable[[HttpRequest], bool]``,
 and if the callable returns ``True``, Basic Auth will be required.
 
+Disable Basic Auth for specific requests
+-------------------------------------
+
+When using the middleware integration, you maybe wan't to exclude a single
+requests from requiring basic auth, e.g. for a healthcheck endpoint. In this
+case you can use the ``basic_auth_disabled`` decorator to disable basic auth for
+this view.
+
+.. code-block:: python
+
+    from basicauth.decorators import basic_auth_disabled
+
+    @basic_auth_disabled
+    def myview(request):
+        ...
+
+
+
 Applying decorator to CBVs
 ==========================
 

--- a/basicauth/decorators.py
+++ b/basicauth/decorators.py
@@ -4,14 +4,21 @@ from .response import HttpResponseUnauthorized
 from .basicauthutils import validate_request
 
 
-def basic_auth_required(func=None,
-                        target_test=(lambda request: True)):
+def basic_auth_disabled(func=None):
+    def _wrapped(request, *args, **kwargs):
+        return func(request, *args, **kwargs)
+
+    return _wrapped
+
+
+def basic_auth_required(func=None, target_test=(lambda request: True)):
     def actual_decorator(view_func):
         @wraps(view_func)
         def _wrapped(request, *args, **kwargs):
             if target_test(request) and not validate_request(request):
                 return HttpResponseUnauthorized()
             return view_func(request, *args, **kwargs)
+
         return _wrapped
 
     if func:


### PR DESCRIPTION
Hey,
I implemented another decorator which can be used to disable BasicAuth on a single view basis if it has been enabled globaly via the middleware integration. This fixes #10 

Best,
Felix