### PR TITLE
Add BASICAUTH_DISABLE_PATHS Setting

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+0.6.0 (2020-11-17)
+----------------------------
+* Added BASICAUTH_DISABLE_PATHS
+    * Thanks @pizzapanther !
+
 0.5.3 (2020-11-17)
 ----------------------------
 * Added supporting Django3 and Python3.8,3.9

--- a/README.rst
+++ b/README.rst
@@ -93,4 +93,5 @@ Settings
 
 * ``BASICAUTH_USERS`` (required): Dictionary including keys as username and values as passwords.
 * ``BASICAUTH_REALM``: realm string, default is "Secure resource".
-* ``BASICAUTH_DISABLE``: Disable all of barriers by this library.
+* ``BASICAUTH_DISABLE``: Disable all barriers by this library.
+* ``BASICAUTH_DISABLE_PATHS``: (List of strings) Disable all barriers when the request path starts with listed paths.

--- a/basicauth/basicauthutils.py
+++ b/basicauth/basicauthutils.py
@@ -49,7 +49,7 @@ def validate_request(request):
     disable_paths = getattr(settings, 'BASICAUTH_DISABLE_PATHS', [])
     if disable_paths:
         disable_paths = tuple(disable_paths)
-        if request.path.startswith(disable_paths)
+        if request.path.startswith(disable_paths):
             return True
 
     if 'HTTP_AUTHORIZATION' not in request.META:

--- a/basicauth/basicauthutils.py
+++ b/basicauth/basicauthutils.py
@@ -46,6 +46,12 @@ def validate_request(request):
         # Not to use this env
         return True
 
+    disable_paths = getattr(settings, 'BASICAUTH_DISABLE_PATHS', [])
+    if disable_paths:
+        disable_paths = tuple(disable_paths)
+        if request.path.startswith(disable_paths)
+            return True
+
     if 'HTTP_AUTHORIZATION' not in request.META:
         return False
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
 
 setup(
     name='django-basicauth',
-    version='0.5.3',
+    version='0.6.0',
     author='Hiroki KIYOHARA',
     author_email='hirokiky@gmail.com',
     url='https://github.com/hirokiky/django-basicauth/',

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -38,3 +38,18 @@ class TestBasicAuthMiddleware(TestCase):
             HTTP_AUTHORIZATION="Basic aW52YWxpZDppbnZhbGlk"
         )
         self.assertEqual(res.content, b"Called; login=None")
+
+
+    @override_settings(BASICAUTH_DISABLE_PATHS=['/decorated/'])
+    def test__disable_barriers(self):
+        res = self.client.get(
+            "/decorated/",
+            HTTP_AUTHORIZATION="Basic aW52YWxpZDppbnZhbGlk"
+        )
+        self.assertEqual(res.content, b"Called; login=None")
+
+        res = self.client.get(
+            "/decorated/sub-path",
+            HTTP_AUTHORIZATION="Basic aW52YWxpZDppbnZhbGlk"
+        )
+        self.assertEqual(res.content, b"Called; login=None")


### PR DESCRIPTION
Adds a setting for disabling basic for certain paths.

### Example:

`BASICAUTH_DISABLE_PATHS = ['/webhook/']`

Matches `request.path` with anything in list: `request.path.startswith(disable_paths)`